### PR TITLE
Update to openjpeg 2.4.0

### DIFF
--- a/.github/workflows/build-deploy.yml
+++ b/.github/workflows/build-deploy.yml
@@ -1,0 +1,41 @@
+name: Build and push iipsrv-openjpeg docker image
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        id: checkout
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v1 
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          builder: ${{ steps.buildx.outputs.name }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: |
+            ghcr.io/dlcs/iipsrv-openjpeg:${{ github.sha }}
+            ghcr.io/dlcs/iipsrv-openjpeg:2.4.0
+
+          

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt-get install -y \
     libfcgi0ldbl libjpeg8 zlib1g-dev libstdc++6 libtool cmake wget  \
     libjpeg-dev libtiff-dev libpng-dev liblcms2-2 libmemcached-dev \
-    lighttpd memcached git autoconf pkg-config gettext-base
+    git autoconf pkg-config gettext-base
 
 # install build-essentials
 RUN apt-get install build-essential -y
@@ -16,7 +16,7 @@ RUN apt-get install build-essential -y
 RUN mkdir -p /opt && cd /opt && git clone https://github.com/uclouvain/openjpeg.git && cd openjpeg && git checkout v2.4.0
 
 # build openjpeg
-RUN cd /opt/openjpeg && cmake -DCMAKE_BUILD_TYPE=Release _DCMAKE_INSTALL_PREFIX=/usr . && make && make install && ldconfig
+RUN cd /opt/openjpeg && cmake -DCMAKE_BUILD_TYPE=Release . && make && make install && ldconfig
 
 # copy openjpeg headers
 RUN cp /usr/local/include/openjpeg-2.4/*.h /opt/openjpeg/src/lib/openjp2/
@@ -29,7 +29,6 @@ RUN apt-get update && apt-get install -y \
     libgomp1 \
     groff \
     gettext-base \
-    memcached \
     && rm -rf /var/lib/apt/lists/*
 
 LABEL maintainer="Donald Gray <donald.gray@digirati.com>"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,28 @@
-FROM ubuntu:14.04
+FROM ubuntu:18.04 as build
 
+# avoid issue with tzdata requiring interaction
+ARG DEBIAN_FRONTEND=noninteractive 
+
+# install required packages
+RUN apt-get update && apt-get install -y \
+    libfcgi0ldbl libjpeg8 zlib1g-dev libstdc++6 libtool cmake wget  \
+    libjpeg-dev libtiff-dev libpng-dev liblcms2-2 libmemcached-dev \
+    lighttpd memcached git autoconf pkg-config gettext-base
+
+# install build-essentials
+RUN apt-get install build-essential -y
+
+# clone openjpeg
+RUN mkdir -p /opt && cd /opt && git clone https://github.com/uclouvain/openjpeg.git && cd openjpeg && git checkout v2.4.0
+
+# build openjpeg
+RUN cd /opt/openjpeg && cmake -DCMAKE_BUILD_TYPE=Release _DCMAKE_INSTALL_PREFIX=/usr . && make && make install && ldconfig
+
+# copy openjpeg headers
+RUN cp /usr/local/include/openjpeg-2.4/*.h /opt/openjpeg/src/lib/openjp2/
+RUN cp /usr/local/lib/libopenjp2.so /opt/openjpeg/bin/.
+
+FROM ubuntu:18.04
 RUN apt-get update && apt-get install -y \
     lighttpd \
     libfcgi \
@@ -7,6 +30,11 @@ RUN apt-get update && apt-get install -y \
     groff \
     gettext-base \
     && rm -rf /var/lib/apt/lists/*
+
+LABEL maintainer="Donald Gray <donald.gray@digirati.com>"
+LABEL org.opencontainers.image.source=https://github.com/dlcs/image-server-node-iipsrv-openjpeg
+
+RUN ldconfig
 
 # dirty way to do it...
 RUN ln -s /usr/lib/x86_64-linux-gnu/libtiff.so.5 /usr/lib/x86_64-linux-gnu/libtiff.so.4
@@ -18,8 +46,16 @@ COPY lighttpd/lighttpd-1.conf.template /etc/lighttpd/lighttpd-1.conf.template
 RUN mkdir -p /var/www/localhost && \
     ln -sf /dev/stdout /tmp/iipsrv-1.log
 
-COPY ./openjpeg.tar.gz /
-RUN cd / && tar -xzvf openjpeg.tar.gz
+COPY --from=build /opt/openjpeg/bin/opj_compress /usr/bin/
+COPY --from=build /opt/openjpeg/bin/opj_decompress /usr/bin/
+COPY --from=build /opt/openjpeg/bin/opj_dump /usr/bin/
+COPY --from=build /opt/openjpeg/bin/libopenjp2.a /usr/lib/
+COPY --from=build /opt/openjpeg/bin/libopenjp2.so /usr/lib/
+COPY --from=build /opt/openjpeg/bin/libopenjp2.so.2.4.0 /usr/lib/
+COPY --from=build /opt/openjpeg/bin/libopenjp2.so.7 /usr/lib/
+COPY --from=build /opt/openjpeg/src/lib/openjp2/openjpeg.h /usr/include/
+COPY --from=build /opt/openjpeg/src/lib/openjp2/opj_config.h /usr/include/
+COPY --from=build /opt/openjpeg/src/lib/openjp2/opj_stdint.h /usr/include/
 
 COPY ./fcgi-bin.tar.gz /var/www/localhost/
 RUN cd /var/www/localhost && tar -xzvf fcgi-bin.tar.gz
@@ -29,3 +65,5 @@ COPY ./operations.sh /
 ENV IMAGE_CACHE_SIZE 128
 
 EXPOSE 8080
+
+CMD [ "/operations.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN apt-get update && apt-get install -y \
     libgomp1 \
     groff \
     gettext-base \
+    memcached \
     && rm -rf /var/lib/apt/lists/*
 
 LABEL maintainer="Donald Gray <donald.gray@digirati.com>"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
 # image-server-node-iipsrv-openjpeg
 
-This has been pushed to DockerHub as fractos/iipsrv-openjpeg:
+A multi stage Dockerfile that builds openjpeg 2.4.0 and copies output to a new stage. 
 
-```
-sudo docker run -d -p=8080:8080 -v /efs:/efs fractos/iipsrv-openjpeg ./operations.sh
+The new stage runs precompiled IIP Image with openjpeg via lighttpd.
+
+This has been pushed to ghcr as `ghcr.io/dlcs/iipsrv-openjpeg:2.4.0` and `ghcr.io/dlcs/iipsrv-openjpeg:2.4.0`
+
+## Running
+
+```sh
+docker build -t iipsrv-openjpeg:local .
+
+docker run -d -p=8080:8080 -v /efs:/efs iipsrv-openjpeg:local ./operations.sh
 ```

--- a/lighttpd/lighttpd-1.conf.template
+++ b/lighttpd/lighttpd-1.conf.template
@@ -3,7 +3,6 @@ server.modules = (
      "mod_alias",
      "mod_compress",
      "mod_redirect"
-     # "mod_fastcgi"
 )
 
 server.document-root        = "/var/www"

--- a/lighttpd/lighttpd-1.conf.template
+++ b/lighttpd/lighttpd-1.conf.template
@@ -2,8 +2,8 @@ server.modules = (
      "mod_access",
      "mod_alias",
      "mod_compress",
-     "mod_redirect",
-     "mod_fastcgi"
+     "mod_redirect"
+     # "mod_fastcgi"
 )
 
 server.document-root        = "/var/www"


### PR DESCRIPTION
Update dockerfile to use multistage build. First stage is building openjpeg 2.4.0. Use prebuild iip-image as there is no newer version.

Added manually triggered github action to push build image to github container registry.